### PR TITLE
Rename seed_database to seed_database_itunes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ do this via the provided management command. It will only do so if the respectiv
 so you won't get duplicates.
 
 ```bash
-python manage.py seed_database
+python manage.py seed_database_itunes
 ```
 
 In order to run the application, you will also need to spawn a django-q cluster using

--- a/src/podcast_analyzer/management/commands/seed_database_itunes.py
+++ b/src/podcast_analyzer/management/commands/seed_database_itunes.py
@@ -1,4 +1,4 @@
-# seed_database.py
+# seed_database_itunes.py
 #
 # Copyright (c) 2024 Daniel Andrlik
 # All rights reserved.

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -9,7 +9,7 @@ import pytest
 from django.core import management
 from django.core.management.base import CommandError
 
-from podcast_analyzer.management.commands import seed_database
+from podcast_analyzer.management.commands import seed_database_itunes
 from podcast_analyzer.models import ItunesCategory
 
 pytestmark = pytest.mark.django_db(transaction=True)
@@ -19,7 +19,7 @@ def test_seed_empty_database() -> None:
     """
     Tries to seed the database and checks for correct results.
     """
-    management.call_command(seed_database.Command())
+    management.call_command(seed_database_itunes.Command())
     assert ItunesCategory.objects.count() == 109
 
 
@@ -30,4 +30,4 @@ def test_seeding_nonempty_database() -> None:
     """
     ItunesCategory.objects.create(name="Dummy Category")
     with pytest.raises(CommandError):
-        management.call_command(seed_database.Command())
+        management.call_command(seed_database_itunes.Command())


### PR DESCRIPTION
This should prevent issues with command naming conflicts in most cases.

Fixes #7