### PR TITLE
🎨 Fix logger name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Minor logging improvements
+
 ## 0.4.0
 
 [Compare the full difference](https://github.com/andrlik/django-podcast-analyzer/compare/v0.3.0...v0.4.0)

--- a/src/podcast_analyzer/models.py
+++ b/src/podcast_analyzer/models.py
@@ -45,7 +45,7 @@ from podcast_analyzer.utils import (
     update_file_extension_from_mime_type,
 )
 
-logger = logging.getLogger("podcast_analyzer")
+logger = logging.getLogger(__name__)
 
 
 KNOWN_GENERATOR_HOST_MAPPING: dict[str, str] = {

--- a/src/podcast_analyzer/receivers.py
+++ b/src/podcast_analyzer/receivers.py
@@ -14,7 +14,7 @@ from django_q.tasks import async_task
 from podcast_analyzer.models import Person, Podcast
 from podcast_analyzer.tasks import async_refresh_feed
 
-logger = logging.getLogger("podcast_analyzer")
+logger = logging.getLogger(__name__)
 
 
 @receiver(post_save, sender=Podcast)

--- a/src/podcast_analyzer/tasks.py
+++ b/src/podcast_analyzer/tasks.py
@@ -10,7 +10,7 @@ import logging
 
 from podcast_analyzer.models import Person, Podcast
 
-logger = logging.getLogger("podcast_analyzer")
+logger = logging.getLogger(__name__)
 
 
 def async_refresh_feed(podcast_id: str) -> None:

--- a/src/podcast_analyzer/views.py
+++ b/src/podcast_analyzer/views.py
@@ -40,7 +40,7 @@ from podcast_analyzer.models import AnalysisGroup, Episode, Person, Podcast
 
 # Create your views here.
 
-logger = logging.getLogger("podcast_analyzer")
+logger = logging.getLogger(__name__)
 
 
 def messaging_enabled() -> bool:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -173,7 +173,7 @@ LOGGING = {
         "podcast_analyzer": {
             "handlers": ["console"],
             "level": "DEBUG",
-            "propagate": True,
+            "propagate": False,
         },
     },
 }


### PR DESCRIPTION
Move to standard practice of getLogger(__name__)

Fixes #37